### PR TITLE
added regressions section

### DIFF
--- a/demo/src/Demo.js
+++ b/demo/src/Demo.js
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import PositionAlignOverview from './PositionAlignOverview'
+import Regressions from './regressions'
+
+export default function Demo() {
+  return (
+    <div>
+      <h1>react-stick</h1>
+
+      <p>
+        <a href="https://github.com/signavio/react-stick">
+          Open documention on Github
+        </a>
+      </p>
+
+      <PositionAlignOverview />
+
+      <Regressions />
+    </div>
+  )
+}

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,23 +1,6 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { render } from 'react-dom'
 
-import PositionAlignOverview from './PositionAlignOverview'
-
-class Demo extends Component {
-  render() {
-    return (
-      <div>
-        <h1>react-stick Demo</h1>
-        <p>
-          Open{' '}
-          <a href="https://github.com/signavio/react-stick">
-            documention on Github
-          </a>
-        </p>
-        <PositionAlignOverview />
-      </div>
-    )
-  }
-}
+import Demo from './Demo'
 
 render(<Demo />, document.querySelector('#demo'))

--- a/demo/src/regressions/ButtonOverlay.js
+++ b/demo/src/regressions/ButtonOverlay.js
@@ -1,0 +1,20 @@
+import React from 'react'
+
+import Stick from '../../../src'
+
+import Regression from './Regression'
+
+export default function ButtonOverlay() {
+  return (
+    <Regression
+      allBrowsers
+      fixed
+      title="Button overlay"
+      description="Stick created an element that prevented clicks to wrapped elements"
+    >
+      <Stick node="This is the sticked text">
+        <button>You should be able to click me</button>
+      </Stick>
+    </Regression>
+  )
+}

--- a/demo/src/regressions/OverlaySize.js
+++ b/demo/src/regressions/OverlaySize.js
@@ -17,16 +17,23 @@ export default function OverlaySize() {
       title="Overlay size"
       description="The overlay should not line-break just because the stick target is small."
     >
-      <div style={{ display: 'flex', justifyContent: 'space-around' }}>
-        <Stick node="This text should stay on one line">
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-around',
+          alignItems: 'center',
+          height: 200,
+        }}
+      >
+        <Stick position="middle right" node="This text should stay on one line">
           <Box width={15} />
         </Stick>
 
-        <Stick node="This text should stay on one line">
+        <Stick position="middle right" node="This text should stay on one line">
           <Box width={50} />
         </Stick>
 
-        <Stick node="This text should stay on one line">
+        <Stick position="middle right" node="This text should stay on one line">
           <Box width={150} />
         </Stick>
       </div>

--- a/demo/src/regressions/OverlaySize.js
+++ b/demo/src/regressions/OverlaySize.js
@@ -1,0 +1,35 @@
+import React from 'react'
+
+import Stick from '../../../src'
+
+import Regression from './Regression'
+
+const Box = ({ width }) => (
+  <div style={{ backgroundColor: 'red', height: 15, width }} />
+)
+
+export default function OverlaySize() {
+  return (
+    <Regression
+      allBrowsers
+      open
+      version="1.0.0"
+      title="Overlay size"
+      description="The overlay should not line-break just because the stick target is small."
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-around' }}>
+        <Stick node="This text should stay on one line">
+          <Box width={15} />
+        </Stick>
+
+        <Stick node="This text should stay on one line">
+          <Box width={50} />
+        </Stick>
+
+        <Stick node="This text should stay on one line">
+          <Box width={150} />
+        </Stick>
+      </div>
+    </Regression>
+  )
+}

--- a/demo/src/regressions/Regression.js
+++ b/demo/src/regressions/Regression.js
@@ -1,0 +1,70 @@
+// @flow
+import * as React from 'react'
+
+type PropsT = {
+  firefox?: boolean,
+  chrome?: boolean,
+  ie?: boolean,
+  edge?: boolean,
+  safari: boolean,
+  opera?: boolean,
+  allBrowsers?: boolean,
+  fixed?: boolean,
+  open?: boolean,
+
+  title: string,
+  description: string,
+  version: string,
+
+  children: React.Node,
+}
+
+function Regression({
+  firefox,
+  chrome,
+  ie,
+  edge,
+  safari,
+  opera,
+  allBrowsers,
+  fixed,
+  open,
+  version,
+  title,
+  description,
+  children,
+}: PropsT) {
+  return (
+    <div>
+      <h2>{title}</h2>
+      <p>{description}</p>
+
+      <div style={{ borderBottom: '1px solid gray' }}>
+        <strong>Browsers:</strong>
+        {firefox && <span style={{ marginLeft: 5 }}>Firefox</span>}
+        {chrome && <span style={{ marginLeft: 5 }}>Chrome</span>}
+        {ie && <span style={{ marginLeft: 5 }}>IE</span>}
+        {edge && <span style={{ marginLeft: 5 }}>Edge</span>}
+        {safari && <span style={{ marginLeft: 5 }}>Safari</span>}
+        {opera && <span style={{ marginLeft: 5 }}>Opera</span>}
+        {allBrowsers && <span style={{ marginLeft: 5 }}>ALL</span>}
+
+        {version && (
+          <span style={{ marginLeft: 20 }}>
+            <strong>Version:</strong> {version}
+          </span>
+        )}
+
+        <span style={{ marginLeft: 20 }}>
+          <strong style={{ marginRight: 5 }}>Status:</strong>
+          {fixed && 'Fixed'}
+          {open && 'Open'}
+        </span>
+      </div>
+
+      <div style={{ padding: 15 }}>{children}</div>
+    </div>
+  )
+}
+
+export default Regression

--- a/demo/src/regressions/Regressions.js
+++ b/demo/src/regressions/Regressions.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import ButtonOverlay from './ButtonOverlay'
+import OverlaySize from './OverlaySize'
+
+export default function Regressions() {
+  return (
+    <div>
+      <h1>Regressions</h1>
+
+      <ButtonOverlay />
+      <OverlaySize />
+    </div>
+  )
+}

--- a/demo/src/regressions/index.js
+++ b/demo/src/regressions/index.js
@@ -1,0 +1,3 @@
+import Regressions from './Regressions'
+
+export default Regressions

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "build-demo": "nwb build-react-component",
     "clean": "nwb clean-module && nwb clean-demo",
     "flow": "flow",
-    "format":
-      "prettier --write --no-semi --single-quote --trailing-comma es5 \"{src,stories}/**/*.js\"",
+    "format": "prettier --write --no-semi --single-quote --trailing-comma es5 \"{src,stories}/**/*.js\"",
     "lint": "eslint --max-warnings=0 --ext .js src tests demo/src",
     "publish-demo": "node scripts/gh-pages-publish.js $CIRCLE_BRANCH",
     "start": "nwb serve-react-demo",
@@ -39,6 +38,7 @@
     "eslint-plugin-react": "^7.1.0",
     "flow-bin": "^0.64.0",
     "gh-pages": "^1.1.0",
+    "inferno": "^3.10.1",
     "nwb": "^0.21.2",
     "prettier": "^1.10.2",
     "react": "^16.2.0",

--- a/src/Stick.js
+++ b/src/Stick.js
@@ -45,13 +45,12 @@ class Stick extends Component<PropsT> {
 
   render() {
     const { inline, node, style, ...rest } = this.props
-    const wrappedNode = node && <div {...style('nodeContent')}>{node}</div>
     const SpecificStick = inline ? StickInline : StickPortal
 
     return (
       <SpecificStick
         {...omit(rest, 'align', 'onClickOutside')}
-        node={wrappedNode}
+        node={node && <div {...style('nodeContent')}>{node}</div>}
         style={style}
         nestingKey={this.getNestingKey()}
         containerRef={this.setContainerRef}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4092,9 +4092,20 @@ indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
 
+inferno-shared@3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/inferno-shared/-/inferno-shared-3.10.1.tgz#6ad59d64ca03c0fdcc8495d4864410cafee81332"
+
 inferno-vnode-flags@3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/inferno-vnode-flags/-/inferno-vnode-flags-3.10.1.tgz#88a4528a3b4df0f33a3ace68dc45f05b651c0e41"
+
+inferno@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/inferno/-/inferno-3.10.1.tgz#5d292e6b1e848ef7f09e3e1b6b2029b703b2baf2"
+  dependencies:
+    inferno-shared "3.10.1"
+    inferno-vnode-flags "3.10.1"
 
 inflection@~1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Certain scenarios are simply not easy to cover with tests, but can be spotted immediately. This PR adds a "Regressions" section to the Demo site. It is intended to describe what is/was going wrong, whether it is fixed, which version was affected and also which browsers. 

Reviewers can then scroll through all regressions and check whether they still look ok. 