### PR TITLE
fix: Correctly define flow types

### DIFF
--- a/src/Stick.js
+++ b/src/Stick.js
@@ -14,7 +14,7 @@ import StickInline from './StickInline'
 import DEFAULT_POSITION from './defaultPosition'
 import { scrollX } from './scroll'
 import getBoundingClientRect from './getBoundingClientRect'
-import type { PrivatePropsT, PositionT } from './flowTypes'
+import type { StickPropsT, PositionT } from './flowTypes'
 
 const PARENT_STICK_NESTING_KEY = 'react-stick__parentStickNestingKey'
 
@@ -38,7 +38,7 @@ const PositionPropType = PropTypes.oneOf([
   'top right',
 ])
 
-class Stick extends Component<PrivatePropsT, StateT> {
+class Stick extends Component<StickPropsT, StateT> {
   containerNestingKeyExtension: number
   containerNode: ?HTMLElement
 
@@ -91,7 +91,9 @@ class Stick extends Component<PrivatePropsT, StateT> {
   render() {
     const { inline, node, style, align, sameWidth, ...rest } = this.props
     const SpecificStick = inline ? StickInline : StickPortal
-    const { style: wrapperStyle = {}, ...wrapperStylingProps } = style('nodeWrapper')
+    const { style: wrapperStyle = {}, ...wrapperStylingProps } = style(
+      'nodeWrapper'
+    )
     return (
       <SpecificStick
         {...omit(rest, 'onClickOutside')}
@@ -128,7 +130,7 @@ class Stick extends Component<PrivatePropsT, StateT> {
     ]).join('_')
   }
 
-  handleClickOutside = (ev: Event) => {
+  handleClickOutside = (ev: MouseEvent) => {
     const { onClickOutside } = this.props
     if (!onClickOutside) {
       return

--- a/src/StickInline.js
+++ b/src/StickInline.js
@@ -5,7 +5,7 @@ import { defaultStyle } from 'substyle'
 import { omit } from 'lodash'
 
 import getModifiers from './getModifiers'
-import type { PrivateSpecificPropsT } from './flowTypes'
+import type { StickInlinePropsT } from './flowTypes'
 
 const StickInline = ({
   node,
@@ -15,10 +15,10 @@ const StickInline = ({
   containerRef,
   nestingKey,
   ...rest
-}: PrivateSpecificPropsT) => {
-  const Comp = component || 'div'
+}: StickInlinePropsT) => {
+  const Component = component || 'div'
   return (
-    <Comp
+    <Component
       ref={ref => {
         containerRef(ref)
       }}
@@ -28,7 +28,7 @@ const StickInline = ({
     >
       {children}
       {node && <div {...style('node')}>{node}</div>}
-    </Comp>
+    </Component>
   )
 }
 

--- a/src/StickPortal.js
+++ b/src/StickPortal.js
@@ -7,7 +7,7 @@ import { createPortal } from 'react-dom'
 
 import { scrollX, scrollY } from './scroll'
 import getBoundingClientRect from './getBoundingClientRect'
-import type { PositionT, PrivateSpecificPropsT } from './flowTypes'
+import type { PositionT, StickPortalPropsT } from './flowTypes'
 
 const PORTAL_HOST_ELEMENT = 'react-stick__portalHostElement'
 
@@ -40,7 +40,7 @@ type StateT = {
   left: number,
 }
 
-class StickPortal extends Component<PrivateSpecificPropsT, StateT> {
+class StickPortal extends Component<StickPortalPropsT, StateT> {
   element: HTMLElement // the element whose position is tracked
   container: HTMLElement // the container for the stick node (has z-index)
   host: HTMLElement // the host element to which we portal the container (has no styles)
@@ -55,7 +55,7 @@ class StickPortal extends Component<PrivateSpecificPropsT, StateT> {
     left: 0,
   }
 
-  constructor(props: PrivateSpecificPropsT) {
+  constructor(props: StickPortalPropsT) {
     super(props)
     this.host = document.createElement('div')
   }
@@ -67,7 +67,7 @@ class StickPortal extends Component<PrivateSpecificPropsT, StateT> {
     }
   }
 
-  componentDidUpdate(prevProps: PrivateSpecificPropsT) {
+  componentDidUpdate(prevProps: StickPortalPropsT) {
     if (this.props.node && !prevProps.node) {
       this.mountHost()
       this.startTracking()

--- a/src/flowTypes.js
+++ b/src/flowTypes.js
@@ -1,5 +1,6 @@
 // @flow
 import type { Substyle } from 'substyle'
+import type { Node } from 'react'
 
 export type PositionT =
   | 'bottom left'
@@ -12,37 +13,52 @@ export type PositionT =
   | 'top center'
   | 'top right'
 
-type CommonPropsT = {
-  node?: React$Element<any>,
-  children?: React$Element<any>,
-  position: PositionT,
-  inline?: boolean,
-  updateOnAnimationFrame?: boolean,
+type SharedPropsT = {
+  node?: Node,
+  children?: Node,
+
   transportTo?: HTMLElement,
+
   component?: string,
-  style: Substyle,
+
+  inline?: boolean,
+
+  updateOnAnimationFrame?: boolean,
+}
+
+type StickBasePropsT = SharedPropsT & {
+  align?: PositionT,
+
+  sameWidth?: boolean,
+
+  onClickOutside?: (ev: MouseEvent) => void,
 }
 
 // the props we are dealing with in Stick
-export type PrivatePropsT = CommonPropsT & {
+export type StickPropsT = StickBasePropsT & {
   // props handled by Stick and not passed further down to specific stick components
-  align?: PositionT,
-  inline?: boolean,
-  sameWidth?: boolean,
-  onClickOutside?: (ev: Event) => void,
-}
-
-// the props we are dealing with in StickInline and StickPortal
-export type PrivateSpecificPropsT = CommonPropsT & {
-  // props injected by Stick
-  containerRef: (element: HTMLElement | null) => void,
-  nestingKey: string,
+  style: Substyle,
+  position: PositionT,
 }
 
 // the props the user has to pass to the Stick
-export type PublicPropsT = PrivatePropsT & {
+export type PublicPropsT = StickBasePropsT & {
   // position is optional, but has a default value
   position?: PositionT,
   // style is optional, but will be injected by substyle
   style?: Substyle,
 }
+
+type SpecificStickBasePropsT = SharedPropsT & {
+  style: Substyle,
+
+  position: PositionT,
+}
+
+export type StickInlinePropsT = SpecificStickBasePropsT & {
+  // props injected by Stick
+  containerRef: (element: ?HTMLElement) => void,
+  nestingKey: string,
+}
+
+export type StickPortalPropsT = StickInlinePropsT


### PR DESCRIPTION
The props that were exported were not correct. For instance, the public interface stated that both `position` and `style` are required props even though they are optional. 