### PR TITLE
fix: Use instance of window.Element

### DIFF
--- a/src/getBoundingClientRect.js
+++ b/src/getBoundingClientRect.js
@@ -7,8 +7,7 @@ function getBoundingClientRect(instance: *): ClientRect {
   const element = findDOMNode(instance)
 
   invariant(
-    element instanceof window.HTMLElement ||
-      element instanceof window.SVGElement,
+    element instanceof window.Element,
     'Cannot retrieve client rect of text or null elements'
   )
 


### PR DESCRIPTION
Some tests fail and, apparently, `window.HTMLElement` and `window.SVGElement` are not the same as `window.Element` (even though [they are](https://github.com/facebook/flow/blob/v0.77/lib/dom.js#L1482)).