### PR TITLE
fix: do not swallow dom props

### DIFF
--- a/src/Stick.js
+++ b/src/Stick.js
@@ -126,6 +126,12 @@ function Stick({
     getModifiers({ position: resolvedPosition, align: resolvedAlign })
   )
 
+  const handleReposition = useCallback(() => {
+    if (nodeRef.current && anchorRef.current) {
+      checkAlignment(nodeRef.current, anchorRef.current)
+    }
+  }, [checkAlignment])
+
   if (!node) {
     const Component = component || 'div'
 
@@ -197,11 +203,7 @@ function Stick({
         style={resolvedStyle}
         nestingKey={nestingKey}
         containerRef={containerRef}
-        onReposition={() => {
-          if (nodeRef.current && anchorRef.current) {
-            checkAlignment(nodeRef.current, anchorRef.current)
-          }
-        }}
+        onReposition={handleReposition}
       >
         {children}
       </StickPortal>

--- a/src/Stick.js
+++ b/src/Stick.js
@@ -42,6 +42,7 @@ function Stick({
   autoFlipHorizontally,
   autoFlipVertically,
   onClickOutside,
+  ...rest
 }: PropsT) {
   const [width, setWidth] = useState(0)
   const [containerNestingKeyExtension] = useState(() => uniqueId())
@@ -126,13 +127,20 @@ function Stick({
   )
 
   if (!node) {
-    return children
+    const Component = component || 'div'
+
+    return (
+      <StickContext.Provider value={nestingKey}>
+        <Component {...rest}>{children}</Component>
+      </StickContext.Provider>
+    )
   }
 
   if (inline) {
     return (
       <StickContext.Provider value={nestingKey}>
         <StickInline
+          {...rest}
           position={resolvedPosition}
           align={resolvedAlign}
           node={
@@ -162,6 +170,7 @@ function Stick({
   return (
     <StickContext.Provider value={nestingKey}>
       <StickPortal
+        {...rest}
         updateOnAnimationFrame={!!updateOnAnimationFrame}
         transportTo={transportTo}
         component={component}

--- a/src/StickInline.js
+++ b/src/StickInline.js
@@ -19,10 +19,16 @@ function StickInline({
   component,
   containerRef,
   nestingKey,
+  ...rest
 }: PropsT) {
   const Component = component || 'div'
   return (
-    <Component {...style} ref={containerRef} data-sticknestingkey={nestingKey}>
+    <Component
+      {...style}
+      {...rest}
+      ref={containerRef}
+      data-sticknestingkey={nestingKey}
+    >
       {children}
       {node && <div {...style('node')}>{node}</div>}
     </Component>

--- a/src/StickPortal.js
+++ b/src/StickPortal.js
@@ -77,6 +77,7 @@ function StickPortal(
   return (
     <Component
       {...style}
+      {...rest}
       ref={node => {
         if (typeof ref === 'function') {
           ref(node)


### PR DESCRIPTION
Some optimizations from the 7.0.0 version did break the API after all. Dang, it! This component would now swallow default DOM handlers such as `onMouseEnter`. Also, it didn't reliably wrap the `children` in the provided `component`.