### PR TITLE
fix: pass styles on correctly

### DIFF
--- a/src/Stick.js
+++ b/src/Stick.js
@@ -137,7 +137,9 @@ function Stick({
 
     return (
       <StickContext.Provider value={nestingKey}>
-        <Component {...rest}>{children}</Component>
+        <Component {...resolvedStyle} {...rest}>
+          {children}
+        </Component>
       </StickContext.Provider>
     )
   }
@@ -149,6 +151,7 @@ function Stick({
           {...rest}
           position={resolvedPosition}
           align={resolvedAlign}
+          style={resolvedStyle}
           node={
             <StickNode
               width={width}

--- a/src/StickInline.js
+++ b/src/StickInline.js
@@ -1,16 +1,10 @@
 // @flow
 import React from 'react'
 import { type HOC } from 'recompose'
-import { type Substyle, defaultStyle } from 'substyle'
+import { defaultStyle } from 'substyle'
 
 import { type StickInlinePropsT } from './flowTypes'
 import { getModifiers } from './utils'
-
-type PropsT = {|
-  ...StickInlinePropsT,
-
-  style: Substyle,
-|}
 
 function StickInline({
   node,
@@ -19,8 +13,10 @@ function StickInline({
   component,
   containerRef,
   nestingKey,
+  align,
+  position,
   ...rest
-}: PropsT) {
+}: StickInlinePropsT) {
   const Component = component || 'div'
   return (
     <Component

--- a/src/flowTypes.js
+++ b/src/flowTypes.js
@@ -74,6 +74,7 @@ type SpecificStickBasePropsT = {|
   node: ?Node,
 
   component: ?string,
+  style: Substyle,
 
   nestingKey: string,
 
@@ -93,8 +94,6 @@ export type StickPortalPropsT = {|
   transportTo: ?HTMLElement,
 
   position: PositionT,
-
-  style: Substyle,
 
   updateOnAnimationFrame: boolean,
 


### PR DESCRIPTION
That's what happens if everything was a `rest` spread :D Now styles are also passed along properly in all scenarios.