### PR TITLE
fix: correctly adjust left scroll position in nested scroll container

### DIFF
--- a/demo/src/AutoAlignment.js
+++ b/demo/src/AutoAlignment.js
@@ -34,28 +34,34 @@ function AutoAlignment() {
 
       <h4>Horizontal flipping</h4>
 
-      <div style={{ height: 350, width: 2000 }}>
-        <Stick
-          autoFlipHorizontally
-          position="middle left"
-          style={{ display: 'inline-block', marginLeft: 250 }}
-          node={
-            <div style={{ backgroundColor: '#ae0d5c', height: 50, width: 200 }}>
-              This is the content of the node
-            </div>
-          }
-        >
-          <div
-            style={{
-              width: 200,
-              height: 100,
-              backgroundColor: 'rgb(24, 170, 177)',
-            }}
+      <div
+        style={{ overflowX: 'auto', border: '1px solid black', padding: 25 }}
+      >
+        <div style={{ height: 350, width: 5000 }}>
+          <Stick
+            autoFlipHorizontally
+            position="middle left"
+            style={{ display: 'inline-block', marginLeft: 250 }}
+            node={
+              <div
+                style={{ backgroundColor: '#ae0d5c', height: 50, width: 200 }}
+              >
+                This is the content of the node
+              </div>
+            }
           >
-            The node of this stick should move to the right if it can't fit to
-            the left
-          </div>
-        </Stick>
+            <div
+              style={{
+                width: 200,
+                height: 100,
+                backgroundColor: 'rgb(24, 170, 177)',
+              }}
+            >
+              The node of this stick should move to the right if it can't fit to
+              the left
+            </div>
+          </Stick>
+        </div>
       </div>
     </div>
   )

--- a/demo/src/regressions/Regressions.js
+++ b/demo/src/regressions/Regressions.js
@@ -3,6 +3,7 @@ import React from 'react'
 import ButtonOverlay from './ButtonOverlay'
 import FitOnPage from './FitOnPage'
 import SameWidth from './SameWidth'
+import ScrollPosition from './ScrollPosition'
 import StickInSvg from './StickInSvg'
 import StickNodeWidth from './StickNodeWidth'
 import StickOnHover from './StickOnHover'
@@ -22,6 +23,7 @@ export default function Regressions() {
       <StyledWithDataAttributes />
       <TransportToFixedContainer />
       <StickOnHover />
+      <ScrollPosition />
     </div>
   )
 }

--- a/demo/src/regressions/ScrollPosition.js
+++ b/demo/src/regressions/ScrollPosition.js
@@ -9,8 +9,8 @@ function ScrollPosition() {
       fixed
       allBrowsers
       version="3.0.3"
-      title="Node should scroll with stick node"
-      description="Scroll to the side. The sticked node should move with the element it was sticked to."
+      title="Node should scroll with anchor node"
+      description="Scroll to the side. The node should move with the anchor node."
     >
       <div style={{ overflow: 'auto', height: 200, border: '1px solid black' }}>
         <div

--- a/demo/src/regressions/ScrollPosition.js
+++ b/demo/src/regressions/ScrollPosition.js
@@ -17,6 +17,8 @@ function ScrollPosition() {
           style={{
             width: 5000,
             height: 5000,
+            marginLeft: 20,
+            marginTop: 20,
             display: 'flex',
             alignItems: 'flex-start',
           }}

--- a/demo/src/regressions/ScrollPosition.js
+++ b/demo/src/regressions/ScrollPosition.js
@@ -1,0 +1,61 @@
+import React from 'react'
+
+import Stick from '../../../es'
+import Regression from './Regression'
+
+function ScrollPosition() {
+  return (
+    <Regression
+      fixed
+      allBrowsers
+      version="3.0.3"
+      title="Node should scroll with stick node"
+      description="Scroll to the side. The sticked node should move with the element it was sticked to."
+    >
+      <div style={{ overflow: 'auto', height: 200, border: '1px solid black' }}>
+        <div
+          style={{
+            width: 5000,
+            height: 5000,
+            display: 'flex',
+            alignItems: 'flex-start',
+          }}
+        >
+          <Stick
+            node={<Node>This node should always stick with its anchor</Node>}
+          >
+            <Anchor>
+              Scroll to the right. The node should move with this element.
+            </Anchor>
+          </Stick>
+        </div>
+      </div>
+    </Regression>
+  )
+}
+
+const Anchor = ({ children }) => (
+  <div
+    style={{
+      padding: 10,
+      backgroundColor: 'rgb(24, 170, 177)',
+      color: 'white',
+    }}
+  >
+    {children}
+  </div>
+)
+
+const Node = ({ children }) => (
+  <div
+    style={{
+      backgroundColor: '#ae0d5c',
+      color: 'white',
+      padding: 10,
+    }}
+  >
+    {children}
+  </div>
+)
+
+export default ScrollPosition

--- a/src/StickPortal.js
+++ b/src/StickPortal.js
@@ -12,10 +12,10 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { inline } from 'substyle'
 import { createPortal } from 'react-dom'
+import { inline } from 'substyle'
 
-import type { PositionT, StickPortalPropsT } from './flowTypes'
+import type { StickPortalPropsT } from './flowTypes'
 import { useWatcher } from './hooks'
 import { scrollX, scrollY } from './utils'
 
@@ -36,8 +36,8 @@ function StickPortal(
   ref
 ) {
   const nodeRef = useRef()
-  const [top, setTop] = useState(0)
-  const [left, setLeft] = useState(0)
+  const [top, setTop] = useState(null)
+  const [left, setLeft] = useState(null)
   const [visible, setVisible] = useState(!!node)
 
   const [host, hostParent] = useHost(transportTo)
@@ -63,14 +63,14 @@ function StickPortal(
   }, [host, hostParent, visible])
 
   const measure = useCallback(() => {
-    if (!nodeRef.current || !visible) {
+    const node = nodeRef.current
+
+    if (!node || !visible) {
       return
     }
 
-    const boundingRect = nodeRef.current.getBoundingClientRect()
-
-    const newTop = calculateTop(position, boundingRect, host)
-    const newLeft = calculateLeft(nodeRef.current, position, boundingRect, host)
+    const newTop = calculateTop(node, position, host)
+    const newLeft = calculateLeft(node, position, host)
 
     if (newTop !== top) {
       setTop(newTop)
@@ -100,22 +100,24 @@ function StickPortal(
     >
       {children}
 
-      <PortalContext.Provider value={host.parentNode}>
-        {createPortal(
-          <div
-            ref={containerRef}
-            data-sticknestingkey={nestingKey}
-            {...inline(style('node'), {
-              position: 'absolute',
-              top,
-              left,
-            })}
-          >
-            {node}
-          </div>,
-          host
-        )}
-      </PortalContext.Provider>
+      {top != null && left != null && (
+        <PortalContext.Provider value={host.parentNode}>
+          {createPortal(
+            <div
+              ref={containerRef}
+              data-sticknestingkey={nestingKey}
+              {...inline(style('node'), {
+                position: 'absolute',
+                top,
+                left,
+              })}
+            >
+              {node}
+            </div>,
+            host
+          )}
+        </PortalContext.Provider>
+      )}
     </Component>
   )
 }
@@ -136,11 +138,8 @@ function useHost(transportTo) {
   return [host, hostParent]
 }
 
-function calculateTop(
-  position: PositionT,
-  { top, height, bottom }: ClientRect,
-  host: Element
-) {
+function calculateTop(node, position, host) {
+  const { top, height, bottom } = node.getBoundingClientRect()
   const fixedHost = getFixedParent(host)
 
   let result = 0
@@ -163,14 +162,11 @@ function calculateTop(
   return result + scrollY()
 }
 
-function calculateLeft(
-  nodeRef,
-  position: PositionT,
-  { left, width, right }: ClientRect,
-  host: Element
-) {
+function calculateLeft(node, position, host) {
+  const { left, width, right } = node.getBoundingClientRect()
+
   const fixedHost = getFixedParent(host)
-  const scrollHost = getScrollParent(nodeRef)
+  const scrollHost = getScrollParent(node)
 
   let result = 0
   if (position.indexOf('left') !== -1) {
@@ -190,10 +186,10 @@ function calculateLeft(
   }
 
   if (scrollHost) {
-    return result + scrollX(nodeRef) - scrollHost.scrollLeft
+    return result + scrollX(node) - scrollHost.scrollLeft
   }
 
-  return result + scrollX(nodeRef)
+  return result + scrollX(node)
 }
 
 function getScrollParent(element) {

--- a/src/StickPortal.js
+++ b/src/StickPortal.js
@@ -207,7 +207,7 @@ function getScrollParent(element) {
 
   const style = getComputedStyle(element)
 
-  if (style.overflowX === 'auto') {
+  if (style.overflowX === 'auto' || style.overflowX === 'scroll') {
     return element
   }
 

--- a/src/StickPortal.js
+++ b/src/StickPortal.js
@@ -63,7 +63,7 @@ function StickPortal(
   }, [host, hostParent, visible])
 
   const measure = useCallback(() => {
-    if (!nodeRef.current) {
+    if (!nodeRef.current || !visible) {
       return
     }
 
@@ -79,7 +79,7 @@ function StickPortal(
     if (newLeft !== left) {
       setLeft(newLeft)
     }
-  }, [host, left, position, top])
+  }, [host, left, position, top, visible])
 
   useWatcher(measure, { updateOnAnimationFrame })
 


### PR DESCRIPTION
Fixes #56 

I've adjusted the `calculateLeft` method to look for the nearest scroll container. This fixes the reported issue. However, be aware that an absolutely positioned node will most likely overlay the scroll container. This means the node will **not** disappear when the anchor is scrolled away. In order to achieve this, you should use the `transportTo` property of the stick to mount the node inside the scroll container.