### PR TITLE
improve performance by adding `enabled` flag to `useWatcher`

### DIFF
--- a/src/Stick.js
+++ b/src/Stick.js
@@ -132,7 +132,7 @@ function Stick({
     }
   }, [resolvedAlign, resolvedPosition, sameWidth, width])
 
-  useWatcher(measure, { updateOnAnimationFrame })
+  useWatcher(measure,  {updateOnAnimationFrame, enabled: !!node} )
 
   const handleReposition = useCallback(() => {
     if (nodeRef.current && anchorRef.current) {

--- a/src/StickPortal.js
+++ b/src/StickPortal.js
@@ -81,7 +81,7 @@ function StickPortal(
     }
   }, [host, left, position, top, visible])
 
-  useWatcher(measure, { updateOnAnimationFrame })
+  useWatcher(measure, { updateOnAnimationFrame, enabled: visible })
 
   const Component = component || 'div'
   return (

--- a/src/hooks/useWatcher.js
+++ b/src/hooks/useWatcher.js
@@ -4,18 +4,19 @@ import { useEffect } from 'react'
 type WatcherFuncT = () => void
 type OptionsT = {|
   updateOnAnimationFrame: boolean,
+  enabled: boolean
 |}
 
 function useWatcher(
   watcher: WatcherFuncT,
-  { updateOnAnimationFrame }: OptionsT
+  { updateOnAnimationFrame, enabled }: OptionsT
 ): void {
   useEffect(() => {
     let animationFrameId
     let idleCallbackId
 
     // do not track in node
-    if (typeof window.requestAnimationFrame !== 'undefined') {
+    if (enabled && typeof window.requestAnimationFrame !== 'undefined') {
       const callback = () => {
         watcher()
 
@@ -38,7 +39,7 @@ function useWatcher(
         cancelIdleCallback(idleCallbackId)
       }
     }
-  }, [updateOnAnimationFrame, watcher])
+  }, [updateOnAnimationFrame, watcher, enabled])
 }
 
 export default useWatcher


### PR DESCRIPTION
- we only need to register the measuring callback if we actually have a `node` prop.
- this reduced a lot of unnecessary computations that made applications with a lot of `Stick` components slow over time.

Here are two performance measurements, using no `node` prop.
This is the status quo:  a lot of CPU usage and calculations going on, even there are no interactions with the page and no `node` needs to be measured:

![react-stick-enabled-usewatch](https://user-images.githubusercontent.com/1227637/98365607-f1ac8100-2032-11eb-8744-d37d143fcb7c.png)

After our opmizations: almost no CPU usage any more in the idle state:
![react-stick-disabled-usewatch](https://user-images.githubusercontent.com/1227637/98365599-ef4a2700-2032-11eb-9291-e6cc3ec9a8d1.png)

