### PR TITLE
fix: add missing dep to fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test": "NODE_ENV=test karma start"
   },
   "dependencies": {
+    "@babel/runtime": "^7.17.9",
     "invariant": "^2.2.4",
     "requestidlecallback": "^0.3.0",
     "substyle": "^9.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1018,7 +1018,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.3.4", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.9", "@babel/runtime@^7.3.4", "@babel/runtime@^7.8.4":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
   integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==


### PR DESCRIPTION
Using https://babel.dev/docs/en/babel-plugin-transform-runtime, we need to specify `@babel/runtime` as an explicit dependency.

It likely worked previously b/c it was part of the whole bundle when using nwb. 