### PR TITLE
chore: allow installing with unmet peerDeps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
 
       - *restore_cache
 
-      - run: npm ci
+      - run: npm ci --force
 
       - save_cache:
           key: deps-v4-{{ .Branch }}-{{ checksum "package-lock.json" }}


### PR DESCRIPTION
npm starting from v7 doesn't allow install dependencies if any of peer depencies were not met, so it throws an error.

Currently we're not able to update all dependencies to fix this issues, so we have to install all deps with `--force` flag.