### PR TITLE
chore: add fortify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,9 +164,9 @@ workflows:
       - approve-fortify-scan:
           type: approval
           filters:
-            branches:
-              only:
-                - master
+            # branches:
+            #   only:
+            #     - master
       - fortify_scan:
           requires:
             - approve-fortify-scan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,10 +163,10 @@ workflows:
     jobs:
       - approve-fortify-scan:
           type: approval
-          # filters:
-          # branches:
-          #   only:
-          #     - master
+          filters:
+          branches:
+            only:
+              - master
       - fortify_scan:
           requires:
             - approve-fortify-scan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,10 +163,10 @@ workflows:
     jobs:
       - approve-fortify-scan:
           type: approval
-          # filters:
-          # branches:
-          #   only:
-          #     - master
+          filters:
+            branches:
+              only:
+                - master
       - fortify_scan:
           requires:
             - approve-fortify-scan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,42 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.3.0
+  fortify: signavio/fortify@2.0.0
+
+executors:
+  fortify:
+    machine:
+      image: ubuntu-2004:202010-01
+    resource-class: large
+
+commands:
+  fortify_scan:
+    parameters:
+      build_id:
+        type: string
+      path:
+        type: string
+      translate_opts:
+        type: string
+        default: ""
+      steps:
+        - fortify/setup
+        - run:
+            name: Fortify translate << parameters.build_id >>
+            command: sourceanalyzer -b << parameters.build_id >> --verbose << parameters.translate_opts >> << parameters.path >>
+        - run:
+            name: Fortify scan << parameters.build_id >>
+            command: sourceanalyzer -b << parameters.build_id >> --verbose -scan -f << parameters.build_id >>.fpr
+        - run:
+            name: "Fortify upload"
+            command: |
+              fortifyclient \
+                -url "$FORTIFY_SSC" \
+                -authtoken "$SSC_API_TOKEN" \
+                uploadFPR \
+                -file << parameters.build_id >>.fpr \
+                -project signavio-react-stick \
+                -version production
 
 references:
   defaults: &defaults
@@ -78,6 +114,14 @@ jobs:
           name: Release
           command: npm run semantic-release
 
+  fortify_scan:
+    executor: fortify
+    steps:
+      - checkout
+      - fortify_scan:
+          build_id: signavio-react-stick
+          path: src
+
 workflows:
   version: 2
   qa-publish-release:
@@ -99,3 +143,32 @@ workflows:
           filters:
             branches:
               only: master
+
+  # Run fortify scan twice a month schedueled
+  schedueled_fortify_scan:
+    triggers:
+      - schedule:
+          # every 1st and 15th of the month
+          cron: "0 0 1,15 * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - fortify_scan:
+          context: fortify
+
+  # Run fortify scan on demand
+  on_demand_fortify_scan:
+    jobs:
+      - approve-fortify-scan:
+          type: approval
+          filters:
+            branches:
+              only:
+                - master
+      - fortify_scan:
+          requires:
+            - approve-fortify-scan
+          context:
+            - fortify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
   fortify:
     machine:
       image: ubuntu-2004:202010-01
-    resource_class: small
+    resource_class: medium
 
 commands:
   fortify_scan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,24 +20,24 @@ commands:
       translate_opts:
         type: string
         default: ""
-      steps:
-        - fortify/setup
-        - run:
-            name: Fortify translate << parameters.build_id >>
-            command: sourceanalyzer -b << parameters.build_id >> --verbose << parameters.translate_opts >> << parameters.path >>
-        - run:
-            name: Fortify scan << parameters.build_id >>
-            command: sourceanalyzer -b << parameters.build_id >> --verbose -scan -f << parameters.build_id >>.fpr
-        - run:
-            name: "Fortify upload"
-            command: |
-              fortifyclient \
-                -url "$FORTIFY_SSC" \
-                -authtoken "$SSC_API_TOKEN" \
-                uploadFPR \
-                -file << parameters.build_id >>.fpr \
-                -project signavio-react-stick \
-                -version production
+    steps:
+      - fortify/setup
+      - run:
+          name: Fortify translate << parameters.build_id >>
+          command: sourceanalyzer -b << parameters.build_id >> -verbose << parameters.translate_opts >> << parameters.path >>
+      - run:
+          name: Fortify scan << parameters.build_id >>
+          command: sourceanalyzer -b << parameters.build_id >> -verbose -scan -f << parameters.build_id >>.fpr
+      - run:
+          name: "Fortify: upload"
+          command: |
+            fortifyclient \
+               -url "$FORTIFY_SSC" \
+               -authtoken "$SSC_API_TOKEN" \
+               uploadFPR \
+               -file << parameters.build_id >>.fpr \
+               -project signavio-react-stick \
+               -version production
 
 references:
   defaults: &defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
   fortify:
     machine:
       image: ubuntu-2004:202010-01
-    resource-class: large
+    resource_class: large
 
 commands:
   fortify_scan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
   fortify:
     machine:
       image: ubuntu-2004:202010-01
-    resource_class: large
+    resource_class: medium
 
 commands:
   fortify_scan:
@@ -163,10 +163,10 @@ workflows:
     jobs:
       - approve-fortify-scan:
           type: approval
-          filters:
-          branches:
-            only:
-              - master
+          # filters:
+          # branches:
+          #   only:
+          #     - master
       - fortify_scan:
           requires:
             - approve-fortify-scan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,10 +163,10 @@ workflows:
     jobs:
       - approve-fortify-scan:
           type: approval
-          filters:
-            # branches:
-            #   only:
-            #     - master
+          # filters:
+          # branches:
+          #   only:
+          #     - master
       - fortify_scan:
           requires:
             - approve-fortify-scan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
   fortify:
     machine:
       image: ubuntu-2004:202010-01
-    resource_class: medium
+    resource_class: small
 
 commands:
   fortify_scan:


### PR DESCRIPTION
As title states, add fortify scan to this repository, I made a test run so the initial result is uploaded. Apparently there is not a single issue. 

As for all the other governance projects this new circle ci job includes 2 options for running the scan:

1. Scheduled every 1st and 15th of a month 
2. On Demand, so a developer needs to approve the check

Upload results can be found here: https://fortify.tools.sap/ssc/html/ssc/version/73700/artifacts/d0/s0?filterSet=a243b195-2120-3f8b-1403-d55b7a7d78e6

Todo: We should still add an alert for new findings.  