### PR TITLE
Update Blackduck orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   fortify: signavio/fortify@2.0.0
-  blackduck: signavio/blackduck@1.11.0
+  blackduck: signavio/blackduck@1.16.2
   codecov: codecov/codecov@3.2.3
 
 executors:


### PR DESCRIPTION
Currently Blackduck is not running, due to the usage of an old orb