### PR TITLE
SIGBMWDEX-297 Update signavio/blackduck to 1.16.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   fortify: signavio/fortify@2.0.0
-  blackduck: signavio/blackduck@1.16.2
+  blackduck: signavio/blackduck@1.16.4
   codecov: codecov/codecov@3.3.0
 
 executors:


### PR DESCRIPTION
Update signavio/blackduck to 1.16.4
For Details see this Slack thread: https://signavio.slack.com/archives/C07E56LAU/p1708933353962709