### PR TITLE
fix(SIGSPM-11659): use Element type for HandleClickOutside handler …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ npm-debug.log*
 /tests/coverage
 /tests/.nyc_output
 cypress
+pnpm-lock.yaml
+yarn.lock
+/.vscode

--- a/src/Stick.tsx
+++ b/src/Stick.tsx
@@ -99,7 +99,7 @@ function Stick({
 
       const { target } = ev
       if (
-        target instanceof (window.HTMLElement || window.SVGElement) &&
+        target instanceof window.Element &&
         isOutside(anchorRef, containerRef, target)
       ) {
         onClickOutside(ev)
@@ -219,7 +219,7 @@ function Stick({
 function isOutside(
   anchorRef: MutableRefObject<HTMLElement | undefined>,
   containerRef: MutableRefObject<HTMLElement | undefined>,
-  target: HTMLElement | SVGElement
+  target: Element
 ) {
   if (anchorRef.current && anchorRef.current.contains(target)) {
     return false

--- a/src/Stick.tsx
+++ b/src/Stick.tsx
@@ -99,7 +99,7 @@ function Stick({
 
       const { target } = ev
       if (
-        target instanceof window.HTMLElement &&
+        target instanceof (window.HTMLElement || window.SVGElement) &&
         isOutside(anchorRef, containerRef, target)
       ) {
         onClickOutside(ev)
@@ -219,7 +219,7 @@ function Stick({
 function isOutside(
   anchorRef: MutableRefObject<HTMLElement | undefined>,
   containerRef: MutableRefObject<HTMLElement | undefined>,
-  target: HTMLElement
+  target: HTMLElement | SVGElement
 ) {
   if (anchorRef.current && anchorRef.current.contains(target)) {
     return false

--- a/tests/src/onClickOutside.test.tsx
+++ b/tests/src/onClickOutside.test.tsx
@@ -27,6 +27,35 @@ describe('`onClickOutside` event', () => {
     cy.get('@spy').should('have.been.called')
   })
 
+  it('should call `onClickOutside` on click on SVGElement outside of the stick node an anchor element', () => {
+    const spy = cy.stub().as('spy')
+    mount(
+      <div data-testid="container">
+        <Stick onClickOutside={spy} node={node}>
+          {anchor}
+        </Stick>
+        <svg
+          viewBox="0 0 300 100"
+          xmlns="http://www.w3.org/2000/svg"
+          stroke="red"
+          fill="grey"
+          data-testid="svg-element"
+        >
+          <circle cx="50" cy="50" r="40" />
+        </svg>
+      </div>
+    )
+
+    cy.findByTestId('svg-element').click({ force: true })
+    cy.get('@spy')
+      .should('have.been.called')
+      .then(() => spy.reset())
+
+    cy.get('body').click({ force: true })
+
+    cy.get('@spy').should('have.been.called')
+  })
+
   it('should not call `onClickOutside` on click on the anchor element or stick node', () => {
     const spy = cy.stub().as('spy')
 


### PR DESCRIPTION
https://jira.tools.sap/browse/SIGSPM-11659

In the editor, when a user click outside the global header on the canvas, it doesn't close the menu. the reason is canvas has SVGElement instead of HTMLElement. therefore I added to the handleClickOutside condition only SVGElement as I don't know what could be the side effect if we allow it all elements.
