### PR TITLE
Update tsconfig.json

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     // "allowJs": true,
     "rootDir": ".",
+    "inlineSources": true,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
make sure the source content is part of the source maps

When compiling our project that uses `react-stick` we get the following warning: 
```
Failed to parse source map from '/Users/abc/work/project/node_modules/react-stick/src/StickNode.tsx' file: Error: ENOENT: no such file or directory
```

when checking the source maps file of the react-stick, we realised that the sourceContent is missing.